### PR TITLE
Judge Server 실행 방법 문서화 및 통신을 위한 기본 유틸 추가

### DIFF
--- a/server/judge/operation.go
+++ b/server/judge/operation.go
@@ -1,0 +1,179 @@
+package judge
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"time"
+)
+
+func HandShake(conn net.Conn) *JudgeInfo {
+	packet := ReceivePacket(conn)
+	if (packet == nil) {
+		return nil
+	}
+
+	jsonBytes, _ := json.MarshalIndent(packet, "", "  ")
+	fmt.Println(string(jsonBytes))
+
+	var info JudgeInfo
+
+	for key, value := range packet {
+		if key == "id" {
+			info.ID = value.(string)
+		} else if key == "key" {
+			info.Key = value.(string)
+		} else if key == "problems" {
+			probs := value.([]interface{})
+			info.Problems = make([]ProblemInfo, len(probs))
+			for index, prob := range probs {
+				nameModPair := prob.([]interface{})
+				info.Problems[index].Name = nameModPair[0].(string)
+				info.Problems[index].Modified = nameModPair[1].(float64)
+			}
+		} else if key == "executors" {
+			exes := value.(map[string]interface{})
+			info.Executors = make([]string, len(exes))
+			i := 0
+			for lang, _ := range exes {
+				info.Executors[i] = lang
+				i += 1
+			}
+		}
+	}
+
+	response := BaseResponse {
+		Name: "handshake-success",
+	}
+	
+	if SendPacket(response, conn) {
+		return &info
+	} else {
+		return nil
+	}
+}
+
+func SendPing(conn net.Conn) net.Conn {
+	fmt.Println("Sending ping...")
+	req := PingRequest {
+		Name: "ping",
+		When: time.Now().String(),
+	}
+
+	if SendPacket(req, conn) {
+		fmt.Println("Sent a ping packet. Waiting for a response...")
+		response := ReceivePacket(conn)
+		fmt.Println("Got Response!")
+		fmt.Println()
+		jsonBytes, _ := json.MarshalIndent(response, "", "  ")
+		fmt.Println(string(jsonBytes))
+	} else {
+		fmt.Println("Couldn't send a packet... Closing connection...")
+		conn.Close()
+		conn = nil
+	}
+
+	return conn
+}
+
+func GetCurrentSubmission(conn net.Conn) net.Conn {
+	fmt.Println("Sending a packet...")
+	req := BaseResponse {
+		Name: "get-current-submission",
+	}
+
+	if SendPacket(req, conn) {
+		fmt.Println("Sent a packet. Waiting for a response...")
+		response := ReceivePacket(conn)
+		fmt.Println("Got Response!")
+		fmt.Println()
+		jsonBytes, _ := json.MarshalIndent(response, "", "  ")
+		fmt.Println(string(jsonBytes))
+	} else {
+		fmt.Println("Couldn't send a packet... Closing connection...")
+		conn.Close()
+		conn = nil
+	}
+
+	return conn
+}
+
+func RequestSubmission(conn net.Conn) net.Conn {
+	var req SubmissionRequest
+	req.Name = "submission-request"
+
+	fmt.Print("Submission ID: ")
+	fmt.Scan(&req.SubmissionID)
+
+	fmt.Print("Problem ID: ")
+	fmt.Scan(&req.ProblemID)
+
+	fmt.Print("Language: ")
+	fmt.Scan(&req.Language)
+
+	fmt.Print("Path of Source: ")
+	var path string
+	fmt.Scan(&path)
+	source, err := ioutil.ReadFile(path)
+	if err != nil {
+		fmt.Println("Invalid path... Try again.")
+		return conn
+	}
+	req.Source = string(source)
+
+	req.TimeLimit = 2
+	req.MemoryLimit = 1024*1024
+	req.ShortCircuit = true
+	req.Meta = ""
+
+	fmt.Println("Sending a packet...")
+
+	if SendPacket(req, conn) {
+		fmt.Println("Sent a packet. Waiting for a response...")
+		for {
+			response := ReceivePacket(conn)
+			fmt.Println()
+			jsonBytes, _ := json.MarshalIndent(response, "", "  ")
+			fmt.Println(string(jsonBytes))
+			if (response["name"].(string) == "grading-end" ||
+				response["name"].(string) == "compile-error" ||
+				response["name"].(string) == "internal-error") {
+				fmt.Println("Done grading.")
+				break
+			}
+		}
+	} else {
+		fmt.Println("Couldn't send a packet... Closing connection...")
+		conn.Close()
+		conn = nil
+	}
+
+	return conn
+}
+
+func TerminateSubmission(conn net.Conn) net.Conn {
+	fmt.Println("Sending a packet...")
+	req := BaseResponse {
+		Name: "terminate-submission",
+	}
+	
+	if !SendPacket(req, conn) {
+		fmt.Println("Couldn't send a packet... Closing connection...")
+		conn.Close()
+		conn = nil
+	}
+
+	return nil
+}
+
+func Disconnect(conn net.Conn) net.Conn {
+	fmt.Println("Disconnecting...")
+	req := BaseResponse {
+		Name: "disconnect",
+	}
+	SendPacket(req, conn)
+
+	conn.Close()
+	return nil
+}

--- a/server/judge/packet.go
+++ b/server/judge/packet.go
@@ -1,0 +1,96 @@
+package judge
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/binary"
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"fmt"
+)
+
+func SendPacket(data interface{}, conn net.Conn) bool {
+	jsonStr, err := json.Marshal(data)
+	if err != nil {
+		fmt.Println("json.Marshal:", err)
+		return false;
+	}
+
+	var buffer bytes.Buffer
+	z := zlib.NewWriter(&buffer)
+	z.Write([]byte(jsonStr))
+	z.Close()
+	compressed := buffer.Bytes()
+	sizeBuffer := make([]byte, 4)
+	binary.BigEndian.PutUint32(sizeBuffer, uint32(len(compressed)))
+	_, err = conn.Write(sizeBuffer)
+	if err != nil {
+		fmt.Println("conn.Write:", err)
+		return false;
+	}
+
+	_, err = conn.Write(compressed)
+	if err != nil {
+		fmt.Println("conn.Write:", err)
+		return false;
+	}
+
+	fmt.Println("Wrote", len(sizeBuffer) + len(compressed), "bytes!")
+
+	return true;
+}
+
+func ReceivePacket(conn net.Conn) map[string]interface{} {
+	sizeBuffer := make([]byte, 4)
+	_, err := conn.Read(sizeBuffer)
+
+	if err != nil {
+		fmt.Println("conn.Read:", err)
+		return nil;
+	}
+
+	size := binary.BigEndian.Uint32(sizeBuffer)
+	fmt.Println("Will receive", size, "bytes...")
+
+	buffer := make([]byte, size)
+	count, err := conn.Read(buffer)
+	fmt.Println("Received", count, "bytes!")
+
+	if err != nil {
+		fmt.Println("conn.Read:", err)
+		return nil;
+	}
+
+	if 0 < count {
+		decoded := DecodePacket(buffer);
+		if decoded == nil {
+			fmt.Println("Failed to DecodePacket")
+			return nil;
+		}
+
+		return decoded
+	}
+
+	return nil;
+}
+
+func DecodePacket(data []byte) map[string]interface{} {
+	reader := bytes.NewReader(data)
+	z, err := zlib.NewReader(reader)
+	if (err != nil) {
+		fmt.Println("zlib.NewReader:", err)
+		return nil
+	}
+
+	defer z.Close()
+	decompressed, err := ioutil.ReadAll(z)
+	if (err != nil) {
+		fmt.Println("ioutil.ReadAll:", err)
+		return nil
+	}
+
+	var parsed map[string]interface{}
+	json.Unmarshal(decompressed, &parsed)
+	return parsed
+}

--- a/server/judge/types.go
+++ b/server/judge/types.go
@@ -1,0 +1,34 @@
+package judge
+
+type ProblemInfo struct {
+	Name		string
+	Modified	float64
+}
+
+type JudgeInfo struct {
+	ID			string
+	Key			string
+	Problems	[]ProblemInfo
+	Executors	[]string
+}
+
+type BaseResponse struct {
+	Name	string	`json:"name"`
+}
+
+type PingRequest struct {
+	Name	string	`json:"name"`
+	When	string	`json:"when"`
+}
+
+type SubmissionRequest struct {
+	Name			string	`json:"name"`
+	SubmissionID	int64	`json:"submission-id"`
+	ProblemID		string	`json:"problem-id"`
+	Language		string	`json:"language"`
+	Source			string	`json:"source"`
+	TimeLimit		int64	`json:"time-limit"`
+	MemoryLimit		int64	`json:"memory-limit"`
+	ShortCircuit	bool	`json:"short-circuit"`
+	Meta			string	`json:"meta"`
+}

--- a/server/readme.md
+++ b/server/readme.md
@@ -1,4 +1,4 @@
-### 사용법
+# 사용법
 
 1. `.env` 파일에서 설정을 확인합니다.
 
@@ -15,8 +15,127 @@
 4. swagger 문서는 http://localhost:5000/swagger/index.html 에서 확인할 수 있으며, api 기본 루트는 `/api/v1`입니다. 예: http://localhost:5000/api/v1/members
 
 
-### 참고문헌
+# judge-server 실행 및 통신 방법
+
+*아래의 과정은 https://docs.dmoj.ca/#/judge/setting_up_a_judge?id=judge-side-setup 의 내용을 참조하여 작성하였습니다.*
+
+judge-server는 윈도우를 지원하지 않고 리눅스 상에서 동작하므로, 아래 과정은 리눅스에서 실행하시거나, 윈도우의 WSL 상에서 실행하셔야 합니다.
+
+## judge-server 설정 파일 만들기
+
+judge-server를 설치 및 실행하기에 앞서, 특정 디렉토리에 judge-server의 세부 설정을 담고 있는 yml 파일을 만들고, 같은 디렉토리에 채점할 문제의 입출력 파일을 준비해야 합니다. **이 문서에서는 `/problems/judge.yml` 파일에 세부 설정을 작성하고, `/problems` 디렉토리에 각 문제들의 입출력 파일을 만드는 것으로 하겠습니다.**
+
+### 1. judge.yml 파일 만들기
+
+`judge.yml` 파일은 judge-server의 세부 설정을 담고 있는 파일로, 아래와 같은 정보를 담고 있습니다.
+
+1. `id`: 채점기의 ID
+2. `key` 채점기의 인증용 키 (단, 이 정보는 이 프로젝트에서는 활용하지 않으므로 임의로 작성하셔도 됩니다.)
+3. `problem_storage_root`: 각 문제의 입출력 데이터를 저장하고 있는 디렉토리 경로
+
+예를 들어, `/problems/judge.yml`의 내용을 아래와 같이 작성할 수 있습니다.
+
+```yml
+id: TestJudge
+key: key_for_testing
+problem_storage_root:
+  - /problems
+```
+
+### 2. 채점할 문제들의 입출력 데이터 추가
+
+각 문제들의 입출력 데이터는 위에서 설정한 `problem_storage_root` 경로(이 문서의 예시에서는 `/problems` 폴더) 아래에 저장해야 합니다. 저장 형식은 아래와 같습니다.
+
+예를 들어, [이 문제의](https://dmoj.ca/problem/aplusb) 문제 데이터를 "aplusb"라는 문제 ID로 저장하고 싶다고 가정 하겠습니다. 문제 ID가 "aplusb"인 문제의 입출력 데이터를 저장하려면, `/problems/aplusb` 디렉토리를 만들고, 그 안에 아래와 같은 파일들을 작성해야 합니다.
+
+1. `{입출력 데이터 번호}.in`: 입력 데이터를 나타냅니다.
+    - `1.in`의 내용을 아래와 같이 작성할 수 있습니다.
+    ```
+    2
+    1 1
+    -1 0
+    ```
+2. `{입출력 데이터 번호}.out`: 출력 데이터를 나타냅니다.
+    - `1.out`의 내용을 아래와 같이 작성할 수 있습니다.
+    ```
+    2
+    -1
+    ```
+3. `init.yml`: 테스트케이스 목록을 정의합니다.
+    - `1.in`, `1.out`, `2.in`, `2.out`와 같은 입출력 데이터가 있다면, `init.yml` 파일의 내용은 아래와 같습니다.
+    ```yml
+    test_cases:
+    - {in: 1.in, out: 1.out, points: 0}
+    - {in: 2.in, out: 2.out, points: 0}
+    ```
+    - 모든 `points` 값을 0으로 설정하면, 채점 도중 단 하나의 테스트 케이스에서라도 오답이 생기면 즉시 채점을 중단하게 됩니다. 반면에 `points` 값이 0이 아닌 값으로 설정되어있다면 하나가 틀리더라도 모든 테스트 케이스를 채점합니다.
+
+## judge-server 실행
+
+실행 방법에는 Docker로 실행하는 방법과 Python 3의 `pip`를 통해 실행하는 방법이 있는데, 여기에서는 Docker로 실행하는 방법을 소개하겠습니다. `pip`로 실행하는 방법은 다음 링크를 참고해주시기 바랍니다.
+
+- https://docs.dmoj.ca/#/judge/setting_up_a_judge?id=judge-side-setup
+
+### Docker 설치
+
+실행 환경에 맞게 Docker를 설치해주세요.
+
+- Ubuntu: https://docs.docker.com/engine/install/ubuntu/
+- WSL 2: https://docs.microsoft.com/ko-kr/windows/wsl/tutorials/wsl-containers
+
+### make 설치
+
+`make` 명령 실행을 위해 `sudo apt install gcc make` 를 실행해주세요.
+
+### Docker 컨테이너 빌드
+
+judge-server 리포지토리를 clone 하여 컨테이너를 빌드해야 합니다.
+
+```bash
+git clone --recursive https://github.com/DMOJ/judge.git
+cd judge/.docker
+sudo make judge-tier1
+```
+
+이 예시에서는 `judge-tier1`을 빌드하고 있는데, tier 1은 tier 1, 2, 3 중 가장 지원하는 언어 수가 적은 컨테이너입니다. 만약 더 많은 언어를 채점하려면 `judge-tier2`, `judge-tier3`를 고려해야 합니다. 지원하는 언어의 구체적인 목록은 아래 Dockerfile에서 확인할 수 있습니다.
+
+- judge-tier1: https://github.com/DMOJ/runtimes-docker/blob/master/tier1/Dockerfile
+- judge-tier2: https://github.com/DMOJ/runtimes-docker/blob/master/tier2/Dockerfile
+- judge-tier3: https://github.com/DMOJ/runtimes-docker/blob/master/tier3/Dockerfile
+
+## Coders 백엔드 실행
+
+Coders 백엔드를 먼저 실행합니다.
+
+```
+go run main.go
+```
+
+## judge-server 컨테이너 실행
+
+위에서 빌드한 Docker 컨테이너를 실행합니다.
+
+```
+sudo docker run \
+    --name judge_name \
+    --network host \
+    -v /home/hyeon/problems:/problems \
+    --cap-add=SYS_PTRACE \
+    -d \
+    --restart=always \
+    dmoj/judge-tier1:latest \
+    run -p "9999" -c /problems/judge.yml "localhost"
+```
+
+이렇게 실행하면 컨테이너가 `judge_name`이라는 이름으로 실행되고, 나중에 이 컨테이너를 종료하거나 삭제하거나 재시작해야 할 일이 있다면 `judge_name`이라는 이름으로 접근할 수 있습니다.
+
+정상적으로 실행되었다면 약 30초~1분 내에 Coders 백엔드와 연결되고, 백엔드에서 채점 기능을 사용할 수 있게 됩니다.
+
+
+# 참고문헌
 
 * 디렉토리 구조: https://github.com/swaggo/swag/tree/master/example/celler
 
 * db 연결: https://github.com/velopert/gin-rest-api-sample
+
+* judge-server 실행: https://docs.dmoj.ca/#/judge/setting_up_a_judge?id=judge-side-setup


### PR DESCRIPTION
1. `server/readme.md`에  judge-server를 어떻게 실행해야 하는지 설명하는 글 추가
2. `server/judge`에 judge-server와 통신하기 위해 기본적으로 필요한 코드들을 추가