### PR TITLE
제출 관련 API 수정

### DIFF
--- a/server/controller/pcomments.go
+++ b/server/controller/pcomments.go
@@ -30,7 +30,7 @@ func ListPComments(ctx *gin.Context) {
 	db := ctx.MustGet("db").(*gorm.DB)
 	problemIdStr := ctx.Param("id")
 	problemId, err := strconv.Atoi(problemIdStr)
-  
+
 	if err != nil {
 		httputil.Error(ctx, http.StatusBadRequest, err)
 		return
@@ -93,11 +93,11 @@ func AddPComment(ctx *gin.Context) {
 	}
 
 	pcomment := model.PComment{
-		Text:    req.Text,
-		CreateAt: time.Now(),
-		Edited:  req.Edited,
-		Deleted: req.Deleted,
-		MemberID: requesterId,
+		Text:      req.Text,
+		CreatedAt: time.Now(),
+		Edited:    req.Edited,
+		Deleted:   req.Deleted,
+		MemberID:  requesterId,
 		ProblemID: req.ProblemID,
 	}
 	result, err := model.PCommentInsert(db, pcomment)
@@ -142,7 +142,7 @@ func UpdatePComment(ctx *gin.Context) {
 
 	comment, err := model.PCommentOne(db, commentId)
 	requesterId := int(claims["id"].(float64))
-	
+
 	// 댓글의 작성자와 수정을 요청한 유저가 동일한 사람인지 확인
 	if comment.MemberID != requesterId {
 		ctx.AbortWithStatus(http.StatusUnauthorized)
@@ -204,13 +204,13 @@ func DeletePComment(ctx *gin.Context) {
 
 	comment, err := model.PCommentOne(db, commentId)
 	requesterId := int(claims["id"].(float64))
-	
+
 	// 댓글의 작성자와 삭제를 요청한 유저가 동일한 사람인지 확인
 	if comment.MemberID != requesterId {
 		ctx.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
-	
+
 	err = model.PCommentDelete(db, commentId)
 	if err != nil {
 		httputil.Error(ctx, http.StatusNotFound, err)

--- a/server/controller/problems.go
+++ b/server/controller/problems.go
@@ -18,7 +18,7 @@ import (
 // @Produce  json
 // @Param num query int false "num"
 // @Param page query int false "page"
-// @Param member query int false "member ID"
+// @Param memberId query int false "member ID"
 // @Param sort query string false "sort"
 // @Param search query string false "search"
 // @Success 200 {array} model.Problem
@@ -40,8 +40,8 @@ func ListProblems(ctx *gin.Context) {
 		page, err = strconv.Atoi(ctx.Query("page"))
 		httputil.CheckError(ctx, err)
 	}
-	if ctx.Query("member") != "" {
-		mid, err = strconv.Atoi(ctx.Query("member"))
+	if ctx.Query("memberId") != "" {
+		mid, err = strconv.Atoi(ctx.Query("memberId"))
 		httputil.CheckError(ctx, err)
 	}
 	search = ctx.Query("search")

--- a/server/controller/submission.go
+++ b/server/controller/submission.go
@@ -105,6 +105,7 @@ func AddSubmission(ctx *gin.Context) {
 		Source:       req.Source,
 		// 첫 상태는 "채점 준비중"이고, 이후 채점기가
 		// IsJudging = true인 Submission을 가져가 채점을 진행하게 됨.
+		// 채점이 완료되면 IsJudging이 false로 설정됨.
 		IsJudging:    true,
 		Result:       "채점 준비중",
 		TimeLimit:    req.TimeLimit,

--- a/server/controller/submission.go
+++ b/server/controller/submission.go
@@ -104,14 +104,16 @@ func AddSubmission(ctx *gin.Context) {
 		Language:     req.Language,
 		Source:       req.Source,
 		// 첫 상태는 "채점 준비중"이고, 이후 채점기가
-		// "채점 준비중"이라고 표시된 Submission을 가져가 채점을 진행하게 됨.
+		// IsJudging = true인 Submission을 가져가 채점을 진행하게 됨.
+		IsJudging:    true,
 		Result:       "채점 준비중",
 		TimeLimit:    req.TimeLimit,
 		MemoryLimit:  req.MemoryLimit,
 		ShortCircuit: req.ShortCircuit,
 		Meta:         req.Meta,
-		CreatedAt:     time.Now(),
+		CreatedAt:    time.Now(),
 	}
+
 	result, err := model.SubmissionInsert(db, Submission)
 	if err != nil {
 		httputil.Error(ctx, http.StatusBadRequest, err)

--- a/server/controller/submission.go
+++ b/server/controller/submission.go
@@ -21,8 +21,8 @@ import (
 // @Tags Submissions
 // @Accept  json
 // @Produce  json
-// @Param problem query int false "problem ID"
-// @Param member query int false "member ID"
+// @Param problemId query int false "problem ID"
+// @Param memberId query int false "member ID"
 // @Param language query string false "language"
 // @Param result query string false "result"
 // @Success 200 {array} model.Submission
@@ -34,8 +34,8 @@ func ListSubmissions(ctx *gin.Context) {
 	db := ctx.MustGet("db").(*gorm.DB)
 
 	param := model.QuerySubmission{
-		ProblemID:	ctx.Query("problem"),
-		MemberID:	ctx.Query("member"),
+		ProblemID:	ctx.Query("problemId"),
+		MemberID:	ctx.Query("memberId"),
 		Language:	ctx.Query("language"),
 		Result:		ctx.Query("result"),
 	}

--- a/server/model/pcomment.go
+++ b/server/model/pcomment.go
@@ -14,7 +14,7 @@ type PComment struct {
 	MemberID  int       `json:"userId" example:"1" format:"int64"`
 	ProblemID int       `json:"problemId" example:"1" format:"int64"`
 	Text      string    `json:"text" example:"problem comment"`
-	CreateAt  time.Time `json:"createdAt"`
+	CreatedAt time.Time `json:"createdAt"`
 	Edited    bool      `json:"edited" example:"false"`
 	Deleted   bool      `json:"deleted" example:"false"`
 }

--- a/server/model/submission.go
+++ b/server/model/submission.go
@@ -45,22 +45,21 @@ type QuerySubmission struct{
 // SubmissionsQuery example
 func SubmissionsQuery(db *gorm.DB, query QuerySubmission) ([]Submission, error) {
 	var submissions []Submission
-	queryColums := make(map[string]interface{})
 
-	if intPid, err := strconv.Atoi(query.ProblemID); err != nil {
-		queryColums["ProblemID"] = intPid
+	if intPid, err := strconv.Atoi(query.ProblemID); query.ProblemID != "" && err != nil {
+		db = db.Where("problem_id = ?", intPid)
 	}
-	if intMid, err := strconv.Atoi(query.MemberID); err != nil {
-		queryColums["MemberID"] = intMid
+	if intMid, err := strconv.Atoi(query.MemberID); query.MemberID != "" &&  err != nil {
+		db = db.Where("member_id = ?", intMid)
 	}
 	if query.Language != "" {
-		queryColums["Language"] = query.Language
+		db = db.Where("language = ?", query.Language)
 	}
 	if query.Result != "" {
-		queryColums["Result"] = query.Result
+		db = db.Where("result = ?", query.Result)
 	}
 
-	err := db.Where(&queryColums).Find(&submissions).Error
+	err := db.Find(&submissions).Error
 	return submissions, err
 }
 

--- a/server/model/submission.go
+++ b/server/model/submission.go
@@ -14,6 +14,7 @@ type Submission struct {
 	ProblemID    int       `json:"problemId" example:"1" format:"int64"` // packet 에서는 problem-id
 	Language     string    `json:"language" example:"C11"`                // 참고: https://github.com/DMOJ/judge-server/tree/master/dmoj/executors
 	Source       string    `json:"source" example:"#include <stdio.h>" type:"text"`
+	IsJudging    bool      `json:"isJudging" example:"true"`
 	Result       string    `json:"result" example:"WA"`
 	TimeLimit    int       `json:"timeLimit" example:"1" format:"int64"`   
 	MemoryLimit  int       `json:"memoryLimit" example:"1" format:"int64"` 

--- a/server/model/submission.go
+++ b/server/model/submission.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strconv"
 	"time"
 
 	"gorm.io/gorm"
@@ -34,8 +35,8 @@ type EditSubmission struct {
 }
 
 type QuerySubmission struct{
-	ProblemID    int   
-	MemberID     int   
+	ProblemID    string   
+	MemberID     string   
 	Language     string
 	Result       string
 }
@@ -43,7 +44,22 @@ type QuerySubmission struct{
 // SubmissionsQuery example
 func SubmissionsQuery(db *gorm.DB, query QuerySubmission) ([]Submission, error) {
 	var submissions []Submission
-	err := db.Where(&query).Find(&submissions).Error
+	queryColums := make(map[string]interface{})
+
+	if intPid, err := strconv.Atoi(query.ProblemID); err != nil {
+		queryColums["ProblemID"] = intPid
+	}
+	if intMid, err := strconv.Atoi(query.MemberID); err != nil {
+		queryColums["MemberID"] = intMid
+	}
+	if query.Language != "" {
+		queryColums["Language"] = query.Language
+	}
+	if query.Result != "" {
+		queryColums["Result"] = query.Result
+	}
+
+	err := db.Where(&queryColums).Find(&submissions).Error
 	return submissions, err
 }
 


### PR DESCRIPTION
답안 제출과 관련된 API를 수정하였습니다.

1. 제출 목록을 쿼리하는 기능이 잘 작동하지 않던 문제를 수정하였습니다.
2. 새로운 제출을 하면 isJudging이 true인 새로운 submission 데이터를 DB에 추가하도록 하였습니다. 추후 이 isJudging column의 값을 토대로 프론트엔드에서는 그 제출이 채점중인지를 알 수 있고, 백엔드에서는 isJudging이 true인 제출을 채점하게 하려 합니다.